### PR TITLE
Add optional name field in mkfs

### DIFF
--- a/vmdb/plugins/mkfs.mdwn
+++ b/vmdb/plugins/mkfs.mdwn
@@ -9,7 +9,17 @@ Step keys:
 
 * `partition` &mdash; REQUIRED; tag for the block device to use.
 
+* `name` &mdash; OPTIONAL; set unique postfix of UUID tmp filename;
+  needed for parallel builds.
+
 Example (in the .vmdb file):
 
     - mkfs: ext4
       partition: root
+
+Same, but with unique UUID filename (ouput = '/path/to/outfile',
+  name = 'outfile'):
+
+    - mkfs: ext4
+      partition: root
+      name: "{{ output.split('/')[-1] }}"

--- a/vmdb/plugins/mkfs_plugin.py
+++ b/vmdb/plugins/mkfs_plugin.py
@@ -36,6 +36,8 @@ class MkfsStepRunner(vmdb.StepRunnerInterface):
         fstype = step['mkfs']
         tag = step['partition']
         device = state.tags.get_dev(tag)
+        # Optional: make UUID tmp file unique
+        name = f"-{step['name']}" if 'name' in step else ""
 
         cmd = ['/sbin/mkfs', '-t', fstype]
         if 'label' in step:
@@ -51,6 +53,6 @@ class MkfsStepRunner(vmdb.StepRunnerInterface):
         output = output.split()
         idx = output.index(b'UUID:')
         uuid = output[idx+1].decode('utf-8')
-        vmdb.runcmd(['echo', uuid], ['tee', '/tmp/grub-uuid'])
+        vmdb.runcmd(['echo', uuid], ['tee', f'/tmp/grub-uuid{name}'])
 
         state.tags.set_fstype(tag, fstype)


### PR DESCRIPTION
Adds an optional name field for the `mkfs` step. If a name is provided, it gets appended to the temporary grub-uuid filename to make it unique. This is required if performing parallel builds so the uuid filenames don't conflict.

E.g:

```yaml
    - mkfs: ext4
      partition: root
      name: "{{ output.split('/')[-1] }}"
```

In this example, if `output` is `/foo/bar/baz`, then `name` will be `baz` and the UUID temporary filename will be `/tmp/grub-uuid-baz`.